### PR TITLE
Update to new URL

### DIFF
--- a/calenderEvents.php
+++ b/calenderEvents.php
@@ -4,11 +4,13 @@ include_once('helper.php');
 
 // Get Calendar events. Make sure the calendar is available for public user
 // otherwise login before
-$url = 'https://mghh.churchtools.de/index.php?q=churchcal/ajax';
+$url = 'https://mghh.church.tools/index.php?q=churchcal/ajax';
 $data = array('func' => 'getCalendarEvents', 
-			  'category_ids' => [1,2,3],
-              'from' => 0,  
-              'to' => '10'); 
+		'category_ids[]' => '1',
+	      	'category_ids[]' => '2',
+	    	'category_ids[]' => '3',
+            	'from' => 0,  
+            	'to' => '10'); 
 $result = sendRequest($url, $data);
 if ($result->status == "fail") {
   echo $result->data;


### PR DESCRIPTION
There was still the old URL of hosted CT installations (see this forum thread: https://forum.church.tools/topic/4095/api-via-php-getcalendarevents) and the category_ids parameter did not work for me.